### PR TITLE
Add Docker support with persistent cache volume

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+build/
+.git/
+.cache/
+*.o

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:bookworm-slim AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git ca-certificates \
+    libcurl4-openssl-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY CMakeLists.txt ./
+COPY src/ src/
+COPY tests/ tests/
+
+RUN mkdir build && cd build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release \
+    && make -j$(nproc)
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcurl4 zlib1g ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/build/meshtile /usr/local/bin/meshtile
+
+ENV HOME=/data
+VOLUME /data/.cache
+
+EXPOSE 8080
+
+ENTRYPOINT ["meshtile"]
+CMD ["--region", "den"]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The full list of available regions is at [meshmapper.net](https://meshmapper.net
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--colormap` | `red_yellow_green` | Tile colormap: `red_yellow_green`, `plasma`, `viridis`, `turbo`, `inferno` |
+| `--colormap` | `plasma` | Tile colormap: `plasma`, `red_yellow_green`, `viridis`, `turbo`, `inferno` |
 
 ### Example
 
@@ -93,6 +93,35 @@ In Google Earth: hamburger menu > Map Style > Add Tile Overlay > `http://host:po
 - Rendered tile PNGs are cached to disk + memory at `~/.cache/meshtile/<region>/tiles/`
 - HGT elevation tiles are cached at `~/.cache/mesh3d/hgt/` (shared with mesh3d)
 - Changing any ITM or RF parameter automatically invalidates cached grids on next run
+
+## Docker
+
+```bash
+docker build -t meshtile .
+docker run -v meshtile-cache:/data/.cache -p 8080:8080 meshtile --region den
+```
+
+Or with Docker Compose:
+
+```yaml
+services:
+  meshtile:
+    image: stevenlafl/meshtile
+    ports:
+      - "8080:8080"
+    volumes:
+      - meshtile-cache:/data/.cache
+    command: ["--region", "den"]
+
+volumes:
+  meshtile-cache:
+```
+
+```bash
+docker compose up
+```
+
+The cache volume persists signal grids and HGT elevation data across container restarts, avoiding expensive recomputation. Each region gets its own cache namespace within the volume.
 
 ## How It Works
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  meshtile:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - meshtile-cache:/data/.cache
+    command: ["--region", "den"]
+
+volumes:
+  meshtile-cache:

--- a/src/types.h
+++ b/src/types.h
@@ -43,7 +43,7 @@ struct RfConfig {
     double location_pct         = 50.0;    // ITM location variability %
     double situation_pct        = 50.0;    // ITM situation variability %
 
-    Colormap colormap = Colormap::red_yellow_green;
+    Colormap colormap = Colormap::plasma;
 };
 
 struct SignalGrid {


### PR DESCRIPTION
 ## Summary

  - Add multi-stage Dockerfile (Debian bookworm-slim, 90MB runtime image)
  - Add docker-compose.yml with named cache volume
  - Add .dockerignore to exclude build artifacts from context
  - Default colormap changed to plasma
  - Update README with Docker usage, compose example, and stevenlafl/meshtile image reference

 ## Test plan

  - docker build -t meshtile . completes successfully
  - docker run starts server and serves tiles (health 200, tile 200)
  - Restart with same volume skips grid recomputation (73 cached, 0 to compute)
  - Switching --region uses separate cache namespace (den/grids/ vs oma/grids/)
  - docker compose up works out of the box
  - Runtime image is 89.8MB (no build toolchain)
  - Image pushed to stevenlafl/meshtile:latest and stevenlafl/meshtile:1.0.1
  
  Resolves #1 